### PR TITLE
Extract null Number properties as NaN

### DIFF
--- a/src/org/osflash/vanilla/Vanilla.as
+++ b/src/org/osflash/vanilla/Vanilla.as
@@ -172,6 +172,8 @@ package org.osflash.vanilla {
 					}
 				}
 			}
+			else if (injectionDetail.type == Number && _allowSimpleTypesConversion)
+				value = parseFloat(value);
 
 			return value;
 		}


### PR DESCRIPTION
This is crucial for JSON, as the AS3 JSON class writes NaN as null to conform to JSON standards. This minor change accounts for this.